### PR TITLE
Initial import of modified ROS sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,136 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(swiftnav_ros)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS diagnostic_updater roscpp sensor_msgs std_srvs std_msgs)
+
+## System dependencies are found with CMake's conventions
+#find_package(swiftnav REQUIRED)
+find_library(SBP sbp)
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and scripts declared therein get installed
+# catkin_python_setup()
+
+#######################################
+## Declare ROS messages and services ##
+#######################################
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+#add_service_files(
+#  FILES
+#)
+
+## Generate added messages and services with any dependencies listed here
+#generate_messages(
+#  DEPENDENCIES
+#  std_msgs
+#)
+
+###################################################
+## Declare things to be passed to other projects ##
+###################################################
+
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+   INCLUDE_DIRS include
+   LIBRARIES sbp_device swiftnav_ros_driver
+   CATKIN_DEPENDS diagnostic_updater roscpp sensor_msgs std_srvs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+add_library(sbp_device
+  src/sbp_device.c
+)
+add_library(swiftnav_ros_driver
+  src/swiftnav_ros_driver.cpp
+)
+
+## Declare a cpp executable
+add_executable(swiftnav_ros_node src/swiftnav_ros_node.cpp)
+add_executable(swiftnav_ros_test src/sbp_device.c)
+
+## Add dependencies to the executable
+# add_dependencies(yei_swiftnav_ros_node ${PROJECT_NAME})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(sbp_device
+  ${SBP}
+)
+target_link_libraries(swiftnav_ros_test
+  ${SBP}
+)
+target_link_libraries(swiftnav_ros_driver
+  sbp
+  sbp_device
+)
+target_link_libraries(swiftnav_ros_node
+  swiftnav_ros_driver
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+## Mark executable scripts (Python etc.) for installation
+## not required for python when using catkin_python_setup()
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS sbp_device swiftnav_ros_driver swiftnav_ros_node swiftnav_ros_test
+# ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+  PATTERN ".svn" EXCLUDE
+)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_yei_swiftnav_ros.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/config/swiftnav_ros_diag.yaml
+++ b/config/swiftnav_ros_diag.yaml
@@ -1,0 +1,7 @@
+pub_rate: 1.0
+analyzers:
+  GPS:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: 'GPS'
+    timeout: 5.0
+    contains: ['piksi_']

--- a/include/swiftnav_ros/sbp_device.h
+++ b/include/swiftnav_ros/sbp_device.h
@@ -1,0 +1,75 @@
+/***************************************************************************//**
+* \file sbp_device.c
+*
+* \brief Standalone C Driver for the Swift-Nav SBP Devices
+* \author Josh Kretzmer
+* \date June 23, 2017
+*
+* Adapted from original Swift-Nav Piksi driver authored by:
+* Scott K Logan
+* Caleb Jamison
+* 
+*
+* API for the standalone C driver
+*
+* \section license License (BSD-3)
+* Copyright (c) 2013, Scott K Logan\n
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of Willow Garage, Inc. nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#ifndef _sbp_device_h
+#define _sbp_device_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <libsbp/sbp.h>
+
+enum piksi_error
+{
+	PIKSI_SUCCESS = 0,
+	PIKSI_ERROR_IO = -1,
+	PIKSI_ERROR_NO_DEVICE = -4,
+	PIKSI_ERROR_NO_MEM = -11,
+	PIKSI_ERROR_OTHER = -13,
+	PIKSI_ERROR_TIMEOUT = -14
+};
+
+int piksi_open( const char *port, int baud );
+void piksi_close( const int8_t piksid );
+
+u8 piksi_spin( const int8_t piksid );
+
+u32 send_cmd( u8 *data, u32 num_bytes, void* context );
+u32 read_data( u8 *data, u32 num_bytes, void* context );
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _sbp_device_h */

--- a/include/swiftnav_ros/swiftnav_ros_driver.h
+++ b/include/swiftnav_ros/swiftnav_ros_driver.h
@@ -1,0 +1,180 @@
+/***************************************************************************//**
+* \file swiftnav_ros_driver.h
+*
+* \brief ROS Implementation of the C Driver (header)
+* \author Josh Kretzmer
+* \date June 23, 2017
+*
+* Adapted from original Swift-Nav Piksi driver authored by:
+* Scott K Logan
+* Caleb Jamison
+*
+* API for the ROS driver
+*
+* \section license License (BSD-3)
+* Copyright (c) 2013, Scott K Logan\n
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of Willow Garage, Inc. nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#ifndef _swiftnav_ros_driver_hpp
+#define _swiftnav_ros_driver_hpp
+
+#include "swiftnav_ros/swiftnav_ros_driver.h"
+
+#include <libsbp/sbp.h>
+
+#include <ros/ros.h>
+#include <ros/rate.h>
+#include <tf/tf.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
+#include <diagnostic_updater/update_functions.h>
+#include <nav_msgs/Odometry.h>
+
+#include <boost/thread.hpp>
+
+namespace swiftnav_ros
+{
+	void heartbeat_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+	void time_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+	void pos_llh_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+	void dops_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+	void baseline_ned_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+	void vel_ned_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+
+	class PIKSI
+	{
+	public:
+		PIKSI( const ros::NodeHandle &_nh = ros::NodeHandle( ),
+			const ros::NodeHandle &_nh_priv = ros::NodeHandle( "~" ),
+			const std::string _port = "/dev/ttyUSB0" );
+		~PIKSI( );
+		bool PIKSIOpen( );
+		void PIKSIClose( );
+	private:
+		bool PIKSIOpenNoLock( );
+		void PIKSICloseNoLock( );
+		void spin( );
+		void spinOnce( );
+		/*!
+		 * \brief Diagnostic update callback
+		 *
+		 * \author Scott K Logan
+		 *
+		 * Whenever the diagnostic_updater deems it necessary to update the values
+		 * therein, this callback is called to fetch the values from the device.
+		 *
+		 * \param[out] stat Structure in which to store the values for
+		 * diagnostic_updater to report
+		 */
+		void DiagCB( diagnostic_updater::DiagnosticStatusWrapper &stat );
+
+		ros::NodeHandle nh;
+		ros::NodeHandle nh_priv;
+		std::string port;
+		std::string frame_id;
+		int8_t piksid;
+		boost::mutex cmd_lock;
+
+		sbp_state_t state;
+		sbp_msg_callbacks_node_t heartbeat_callback_node;
+		sbp_msg_callbacks_node_t time_callback_node;
+//		sbp_msg_callbacks_node_t pos_ecef_callback_node;
+		sbp_msg_callbacks_node_t pos_llh_callback_node;
+		sbp_msg_callbacks_node_t dops_callback_node;
+//		sbp_msg_callbacks_node_t baseline_ecef_callback_node;
+		sbp_msg_callbacks_node_t baseline_ned_callback_node;
+//		sbp_msg_callbacks_node_t vel_ecef_callback_node;
+		sbp_msg_callbacks_node_t vel_ned_callback_node;
+
+		/*
+		 * Diagnostic updater
+		 */
+		diagnostic_updater::Updater heartbeat_diag;
+		diagnostic_updater::Updater llh_diag;
+		diagnostic_updater::Updater rtk_diag;
+		/*
+		 * Normal acceptable update rates for LLH, RTK, Heartbeat
+		 */
+		double min_llh_rate;
+		double max_llh_rate;
+        double min_rtk_rate;
+        double max_rtk_rate;
+        double min_heartbeat_rate;
+        double max_heartbeat_rate;
+
+		/*!
+		 * \brief Diagnostic rate for gps/rtk publication
+		 */
+		diagnostic_updater::FrequencyStatus llh_pub_freq;
+		diagnostic_updater::FrequencyStatus rtk_pub_freq;
+		diagnostic_updater::FrequencyStatus heartbeat_pub_freq;
+
+		ros::Publisher llh_pub;
+		ros::Publisher rtk_pub;
+		ros::Publisher time_pub;
+
+        // Diagnostic Data
+		unsigned int io_failure_count;
+		unsigned int last_io_failure_count;
+		unsigned int open_failure_count;
+		unsigned int last_open_failure_count;
+        unsigned int heartbeat_flags;       //!< Flags from heartbeat msg
+        unsigned int sbp_protocol_version;
+        unsigned int num_llh_satellites;   //!< Number of satellites used in llh soln
+        unsigned int llh_status;           //!< Flags from POS_LLH message - bit 0: rtk
+        double llh_lat;
+        double llh_lon;
+        double llh_height;
+        double llh_h_accuracy;
+        double llh_v_accuracy;
+        double hdop;
+
+        unsigned int num_rtk_satellites;   //!< Number of satellites used in rtk soln
+        unsigned int rtk_status;           //!< Flags from BASELINE_NED message
+        double rtk_north;
+        double rtk_east;
+        double rtk_height;
+        double rtk_h_accuracy;
+        double rtk_v_accuracy;
+        double rtk_vel_north;
+        double rtk_vel_east;
+        double rtk_vel_up;
+        double rtk_vel_v_covariance;
+        double rtk_vel_h_covariance;
+
+		ros::Rate spin_rate;
+		boost::thread spin_thread;
+
+		friend void heartbeat_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+		friend void time_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+		friend void pos_llh_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+		friend void baseline_ned_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+		friend void vel_ned_callback(u16 sender_id, u8 len, u8 msg[], void *context);
+	};
+}
+
+#endif /* _piksi_driver_hpp */

--- a/include/swiftnav_ros/swiftnav_ros_driver.h
+++ b/include/swiftnav_ros/swiftnav_ros_driver.h
@@ -42,7 +42,7 @@
 #ifndef _swiftnav_ros_driver_hpp
 #define _swiftnav_ros_driver_hpp
 
-#include "swiftnav_ros/swiftnav_ros_driver.h"
+#include "swiftnav_ros/sbp_device.h"
 
 #include <libsbp/sbp.h>
 

--- a/launch/swiftnav_ros.launch
+++ b/launch/swiftnav_ros.launch
@@ -1,0 +1,10 @@
+<launch>
+   <node pkg="swiftnav_ros" type="swiftnav_ros_node" name="swiftnav_ros_node" output="screen">
+     <param name="port" value="/dev/ttyUSB0" />
+   </node>
+   
+   <node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostic_aggregator" >
+      <rosparam command="delete" param="/diagnostic_aggregator" />
+      <rosparam command="load" file="$(find swiftnav_ros)/config/swiftnav_ros_diag.yaml" />
+   </node>
+</launch>

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -1,0 +1,14 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b swiftnav_ros 
+
+<!-- 
+Provide an overview of your package.
+-->
+
+-->
+
+
+*/

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package>
+  <name>swiftnav_ros</name>
+  <version>0.0.1</version>
+  <description>Swift Navigation ROS Driver for SBP Devices</description>
+
+  <maintainer email="jkretzmer@swiftnav.com">Josh Kretzmer</maintainer>
+
+  <license>BSD</license>
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://ros.org/wiki/yei_tss_usb</url> -->
+
+  <author email="logans@cottsay.net">Scott K Logan</author>
+  <author email="cbjamo@gmail.com">Caleb Jamison</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>diagnostic_updater</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <build_depend>libswiftnav</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>diagnostic_updater</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
+  <run_depend>libswiftnav</run_depend>
+</package>

--- a/src/sbp_device.c
+++ b/src/sbp_device.c
@@ -1,0 +1,236 @@
+/***************************************************************************//**
+* \file sbp_device.c
+*
+* \brief Standalone C Driver for the Swift-Nav SBP Devices
+* \author Josh Kretzmer
+* \date June 23, 2017
+*
+* Adapted from original Swift-Nav Piksi driver authored by:
+* Scott K Logan
+* Caleb Jamison
+* 
+*
+* This is a standalone C driver for the Swift Navigation SBP Devices.
+*
+* \section license License (BSD-3)
+* Copyright (c) 2013, Scott K Logan\n
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* - Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+* - Neither the name of Willow Garage, Inc. nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#include "swiftnav_ros/sbp_device.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <termios.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+/*!
+ * \brief Maximum number of simultaneously open device handles.
+ */
+#define MAX_HANDLES 256
+
+#define NO_FLUSH_BUFFER 1
+
+struct piksi_priv
+{
+	int fd;
+	int baud;
+	char *port;
+};
+
+/*!
+ * \brief List of communication handles.
+ */
+static struct piksi_priv * piksi_list[MAX_HANDLES] = { NULL };
+
+
+/*!
+ * \brief Grabs the next available device handle slot.
+ *
+ * Iterates through the ::MAX_HANDLES slots for the lowest available index.
+ *
+ * \returns Open slot index between 0 and ::MAX_HANDLES
+ * \retval -1 No available slots
+ */
+static int next_available_handle( )
+{
+	unsigned short int i;
+	for( i = 0; i < MAX_HANDLES; i++ )
+	{
+		if( !piksi_list[i] )
+			return i;
+	}
+	return -1;
+}
+
+static int baud2term( int baud )
+{
+	switch( baud )
+	{
+	case 1200:
+		return B1200;
+		break;
+	case 2400:
+		return B2400;
+		break;
+	case 4800:
+		return B4800;
+		break;
+	case 9600:
+		return B9600;
+		break;
+	case 19200:
+		return B19200;
+		break;
+	case 38400:
+		return B38400;
+		break;
+	case 57600:
+		return B57600;
+		break;
+	case 115200:
+		return B115200;
+		break;
+	case 230400:
+		return B230400;
+		break;
+	case 460800:
+		return B460800;
+		break;
+	case 921600:
+		return B921600;
+		break;
+	case 1000000:
+		return B1000000;
+		break;
+	default:
+		return B0;
+		break;
+	}
+}
+
+u32 send_cmd( u8 *data, u32 num_bytes, void* context )
+{
+	int8_t piksid = *( int8_t* ) context;
+	return write( piksi_list[piksid]->fd, data, num_bytes );
+}
+
+u32 read_data( u8 *data, u32 num_bytes, void* context )
+{
+	int8_t piksid = *( int8_t* ) context;
+	u32 bytes_recv = 0;
+	u32 bytes_recvd = 0;
+	while( num_bytes )
+	{
+		bytes_recv = read( piksi_list[piksid]->fd, data, num_bytes );
+		if( bytes_recv <= 0 )
+			return 0;
+		num_bytes -= bytes_recv;
+		bytes_recvd += bytes_recv;
+	}
+	return bytes_recvd;
+}
+
+
+int piksi_open( const char *port, int baud )
+{
+	/* Step 1: Make sure the device opens OK */
+	int fd = open( port, O_RDWR | O_NOCTTY | O_NDELAY );
+	if( fd < 0 )
+		return PIKSI_ERROR_NO_DEVICE;
+
+	fcntl( fd, F_SETFL, 0 );
+
+	struct termios options;
+	cfmakeraw( &options );
+	if( cfsetispeed( &options, baud2term(baud) ) < 0 )
+	{
+		close( fd );
+		return PIKSI_ERROR_IO;
+	}
+	options.c_cflag &= ~HUPCL;
+	options.c_lflag &= ~ICANON;
+	options.c_cc[VTIME] = 2;
+	options.c_cc[VMIN] = 0;
+	if( tcsetattr( fd, TCSANOW, &options ) < 0 )
+	{
+		close( fd );
+		return PIKSI_ERROR_IO;
+	}
+
+	/* Step 2: Allocate a private struct */
+	int mydev = next_available_handle( );
+	if( mydev < 0 )
+		goto close_mem_error;
+
+	piksi_list[mydev] = malloc( sizeof( struct piksi_priv ) );
+	if( !piksi_list[mydev] )
+		goto null_struct;
+
+	memset( piksi_list[mydev], 0, sizeof( struct piksi_priv ) );
+
+	piksi_list[mydev]->port = malloc( strlen( port ) + 1 );
+	if( !piksi_list[mydev]->port )
+		goto free_struct;
+
+	memcpy( piksi_list[mydev]->port, port, strlen( port ) + 1 );
+	piksi_list[mydev]->fd = fd;
+	piksi_list[mydev]->baud = baud2term(baud);
+
+	return mydev;
+
+	/* Free gotos */
+
+	free_struct:
+		free( piksi_list[mydev] );
+	null_struct:	
+		piksi_list[mydev] = NULL;
+	close_mem_error:
+		close( fd );
+		return PIKSI_ERROR_NO_MEM;
+}
+
+void piksi_close( const int8_t piksid )
+{
+	if( piksid < 0 || piksid > MAX_HANDLES || !piksi_list[piksid] )
+		return;
+
+	close( piksi_list[piksid]->fd );
+
+	free( piksi_list[piksid]->port );
+	free( piksi_list[piksid] );
+	piksi_list[piksid] = NULL;
+
+	return;
+}
+
+int main()
+{
+	return 0;
+}
+

--- a/src/swiftnav_ros_driver.cpp
+++ b/src/swiftnav_ros_driver.cpp
@@ -1,0 +1,427 @@
+#include "swiftnav_ros/swiftnav_ros_driver.h"
+#include <libsbp/system.h>
+#include <libsbp/navigation.h>
+
+#include <iomanip>
+
+#include <sensor_msgs/NavSatFix.h>
+#include <sensor_msgs/NavSatStatus.h>
+#include <sensor_msgs/TimeReference.h>
+#include <ros/time.h>
+#include <tf/tf.h>
+
+namespace swiftnav_ros
+{	
+	PIKSI::PIKSI( const ros::NodeHandle &_nh,
+		const ros::NodeHandle &_nh_priv,
+		const std::string _port ) :
+		nh( _nh ),
+		nh_priv( _nh_priv ),
+		port( _port ),
+		frame_id( "gps" ),
+		piksid( -1 ),
+
+        heartbeat_diag(nh, nh_priv, "ppiksi_time_diag"),
+        llh_diag(nh, nh_priv, "ppiksi_llh_diag"),
+        rtk_diag(nh, nh_priv, "ppiksi_rtk_diag"),
+
+		min_llh_rate( 0.5 ),
+		max_llh_rate( 50.0 ),
+		min_rtk_rate( 0.5 ),
+		max_rtk_rate( 50.0 ),
+		min_heartbeat_rate( 0.5 ),
+		max_heartbeat_rate( 50.0 ),
+
+		llh_pub_freq( diagnostic_updater::FrequencyStatusParam(
+                    &min_llh_rate, &max_llh_rate, 0.1, 50 ) ),
+		rtk_pub_freq( diagnostic_updater::FrequencyStatusParam( 
+                    &min_rtk_rate, &max_rtk_rate, 0.1, 50 ) ),
+		heartbeat_pub_freq( diagnostic_updater::FrequencyStatusParam( 
+                    &min_rtk_rate, &max_rtk_rate, 0.1, 50 ) ),
+
+		io_failure_count( 0 ),
+		last_io_failure_count( 0 ),
+		open_failure_count( 0 ),
+		last_open_failure_count( 0 ),
+        heartbeat_flags( 0 ),
+
+        num_llh_satellites( 0 ),
+        llh_status( 0 ),
+        llh_lat( 0.0 ),
+        llh_lon( 0.0 ),
+        llh_height( 0.0 ),
+        llh_h_accuracy( 0.0 ),
+        hdop( 1.0 ),
+
+        rtk_status( 0 ),
+        num_rtk_satellites( 0 ),
+        rtk_north( 0.0 ),
+        rtk_east( 0.0 ),
+        rtk_height( 0.0 ),
+        rtk_h_accuracy( 0.04 ),     // 4cm
+
+		spin_rate( 2000 ),      // call sbp_process this fast to avoid dropped msgs
+		spin_thread( &PIKSI::spin, this )
+	{
+		cmd_lock.unlock( );
+		heartbeat_diag.setHardwareID( "piksi heartbeat" );
+        heartbeat_diag.add( heartbeat_pub_freq );
+
+		llh_diag.setHardwareID( "piksi lat/lon" );
+		llh_diag.add( llh_pub_freq );
+
+		rtk_diag.setHardwareID( "piksi rtk" );
+		rtk_diag.add( "Piksi Status", this, &PIKSI::DiagCB );
+		rtk_diag.add( rtk_pub_freq );
+
+		nh_priv.param( "frame_id", frame_id, (std::string)"gps" );
+	}
+
+	PIKSI::~PIKSI( )
+	{
+		spin_thread.interrupt( );
+		PIKSIClose( );
+	}
+
+	bool PIKSI::PIKSIOpen( )
+	{
+		boost::mutex::scoped_lock lock( cmd_lock );
+		return PIKSIOpenNoLock( );
+	}
+
+	bool PIKSI::PIKSIOpenNoLock( )
+	{
+		if( piksid >= 0 )
+			return true;
+
+		piksid = piksi_open( port.c_str( ) , 115200);
+
+		if( piksid < 0 )
+		{
+			open_failure_count++;
+			return false;
+		}
+
+		sbp_state_init(&state);
+		sbp_state_set_io_context(&state, &piksid);
+
+        sbp_register_callback(&state, SBP_MSG_HEARTBEAT, &heartbeat_callback, (void*) this, &heartbeat_callback_node);
+        sbp_register_callback(&state, SBP_MSG_GPS_TIME, &time_callback, (void*) this, &time_callback_node);
+        sbp_register_callback(&state, SBP_MSG_POS_LLH, &pos_llh_callback, (void*) this, &pos_llh_callback_node);
+//		sbp_register_callback(&state, SBP_BASELINE_ECEF, &baseline_ecefCallback, (void*) this, &baseline_ecef_callback_node);
+        sbp_register_callback(&state, SBP_MSG_BASELINE_NED, &baseline_ned_callback, (void*) this, &baseline_ned_callback_node);
+//		sbp_register_callback(&state, SBP_VEL_ECEF, &vel_ecefCallback, (void*) this, &vel_ecef_callback_node);
+		sbp_register_callback(&state, SBP_MSG_VEL_NED, &vel_ned_callback, (void*) this, &vel_ned_callback_node);
+
+		llh_pub = nh.advertise<sensor_msgs::NavSatFix>( "gps/fix", 1 );
+		rtk_pub = nh.advertise<nav_msgs::Odometry>( "gps/rtkfix", 1 );
+		time_pub = nh.advertise<sensor_msgs::TimeReference>( "gps/time", 1 );
+
+		return true;
+	}
+
+	void PIKSI::PIKSIClose( )
+	{
+		boost::mutex::scoped_lock lock( cmd_lock );
+		PIKSICloseNoLock( );
+	}
+
+	void PIKSI::PIKSICloseNoLock( )
+	{
+		int8_t old_piksid = piksid;
+		if( piksid < 0 )
+		{
+			return;
+		}
+		piksid = -1;
+		piksi_close( old_piksid );
+		if( llh_pub )
+			llh_pub.shutdown( );
+		if( time_pub )
+			time_pub.shutdown( );
+	}
+
+	void heartbeat_callback(u16 sender_id, u8 len, u8 msg[], void *context)
+	{
+		if ( context == NULL )
+		{
+			std::cerr << "Critical Error: Pisk SBP driver heartbeat context void." << std::endl;
+			return;
+		}
+		
+		msg_heartbeat_t hb = *(msg_heartbeat_t*) msg;
+
+		class PIKSI *driver = (class PIKSI*) context;
+        driver->heartbeat_pub_freq.tick();
+        driver->heartbeat_flags |= (hb.flags & 0x7);    // accumulate errors for diags
+        driver->sbp_protocol_version =(hb.flags & 0xFF0000)>>16;
+    if  (driver->sbp_protocol_version < 2) {
+		    std::cerr << "SBP Major protocol version mismatch. "
+                     "Driver compatible with 2.0 and later. Version " 
+                      << driver->sbp_protocol_version << driver->heartbeat_flags << " detected." << std::endl;
+		return;
+	}
+}
+
+	void time_callback(u16 sender_id, u8 len, u8 msg[], void *context)
+	{
+		if ( context == NULL )
+		{
+			std::cerr << "Critical Error: Pisk SBP driver time context void." << std::endl;
+			return;
+		}
+
+		class PIKSI *driver = (class PIKSI*) context;
+
+		msg_gps_time_t time = *(msg_gps_time_t*) msg;
+    if ((time.flags&0x7) != 0) {
+
+      sensor_msgs::TimeReferencePtr time_msg( new sensor_msgs::TimeReference );
+
+      time_msg->header.frame_id = driver->frame_id;
+      time_msg->header.stamp = ros::Time::now( );
+
+      time_msg->time_ref.sec = time.tow;
+      time_msg->source = "gps";
+
+      driver->time_pub.publish( time_msg );
+    }
+        
+
+		return;
+	}
+
+	void pos_llh_callback(u16 sender_id, u8 len, u8 msg[], void *context)
+	{
+		if ( context == NULL )
+		{
+			std::cerr << "Critical Error: Pisk SBP driver pos_llh context void." << std::endl;
+			return;
+		}
+
+		class PIKSI *driver = (class PIKSI*) context;
+
+		msg_pos_llh_t llh = *(msg_pos_llh_t*) msg;
+          
+          // populate diagnostic data
+          driver->llh_pub_freq.tick( );
+          driver->llh_status |= llh.flags;
+    
+    if ((llh.flags&0x7) != 0) {
+
+      sensor_msgs::NavSatFixPtr llh_msg( new sensor_msgs::NavSatFix );
+
+      llh_msg->header.frame_id = driver->frame_id;
+      llh_msg->header.stamp = ros::Time::now( );
+
+      llh_msg->status.status = 0;
+      llh_msg->status.service = 1;
+
+      llh_msg->latitude = llh.lat;
+      llh_msg->longitude = llh.lon;
+      llh_msg->altitude = llh.height;
+
+      // populate the covariance matrix
+      double h_covariance = llh.h_accuracy * llh.h_accuracy * 10e-6;
+      double v_covariance = llh.v_accuracy * llh.v_accuracy * 10e-6;
+      llh_msg->position_covariance[0]  = h_covariance;   // x = 0, 0 
+      llh_msg->position_covariance[4]  = h_covariance;   // y = 1, 1 
+      llh_msg->position_covariance[8]  = v_covariance;   // z = 2, 2 
+
+      driver->llh_pub.publish( llh_msg );
+
+          driver->num_llh_satellites = llh.n_sats;
+          driver->llh_lat = llh.lat;
+          driver->llh_lon = llh.lon;
+          driver->llh_height = llh.height;
+          driver->llh_h_accuracy = llh.h_accuracy / 1000.0;
+          driver->llh_v_accuracy = llh.v_accuracy / 1000.0;
+    }
+		return;
+	}
+
+	void baseline_ned_callback(u16 sender_id, u8 len, u8 msg[], void *context)
+	{
+
+		if ( context == NULL )
+		{
+			std::cerr << "Critical Error: Pisk SBP driver baseline context void." << std::endl;
+			return;
+		}
+
+		class PIKSI *driver = (class PIKSI*) context;
+
+		msg_baseline_ned_t sbp_ned = *(msg_baseline_ned_t*) msg;
+          
+            // save diagnostic data
+            driver->rtk_pub_freq.tick( );
+            driver->rtk_status = sbp_ned.flags;
+
+    if ((sbp_ned.flags&0x7) != 0) {
+        nav_msgs::OdometryPtr rtk_odom_msg( new nav_msgs::Odometry );
+
+        rtk_odom_msg->header.frame_id = driver->frame_id;
+            // For best accuracy, header.stamp should maybe get tow converted to ros::Time
+        rtk_odom_msg->header.stamp = ros::Time::now( );
+
+            // convert to meters from mm, and NED to ENU
+        rtk_odom_msg->pose.pose.position.x = sbp_ned.e/1000.0;
+        rtk_odom_msg->pose.pose.position.y = sbp_ned.n/1000.0;
+        rtk_odom_msg->pose.pose.position.z = -sbp_ned.d/1000.0;
+
+        // Set orientation to 0; GPS doesn't provide orientation
+        rtk_odom_msg->pose.pose.orientation.x = 0;
+        rtk_odom_msg->pose.pose.orientation.y = 0;
+        rtk_odom_msg->pose.pose.orientation.z = 0;
+        rtk_odom_msg->pose.pose.orientation.w = 0;
+
+        // populate the pose covariance matrix if we have a good fix
+        double h_covariance = (sbp_ned.h_accuracy * sbp_ned.h_accuracy) / 1.0e-6;
+        double v_covariance = (sbp_ned.v_accuracy * sbp_ned.v_accuracy) / 1.0e-6;
+
+        // Pose x/y/z covariance 
+        rtk_odom_msg->pose.covariance[0]  = h_covariance;   // x = 0, 0 in the 6x6 cov matrix
+        rtk_odom_msg->pose.covariance[7]  = h_covariance;   // y = 1, 1
+        rtk_odom_msg->pose.covariance[14] = v_covariance;  // z = 2, 2
+
+        // default angular pose to unknown
+        rtk_odom_msg->pose.covariance[21] = 1.0e3;  // x rotation = 3, 3
+        rtk_odom_msg->pose.covariance[28] = 1.0e3;  // y rotation = 4, 4
+        rtk_odom_msg->pose.covariance[35] = 1.0e3;  // z rotation = 5, 5
+
+        // Populate linear part of Twist with last velocity reported: by vel_ned_callback
+        rtk_odom_msg->twist.twist.linear.x = driver->rtk_vel_east;
+        rtk_odom_msg->twist.twist.linear.y = driver->rtk_vel_north;
+        rtk_odom_msg->twist.twist.linear.z = driver->rtk_vel_up;
+
+        // Set angular velocity to 0 - GPS doesn't provide angular velocity
+        rtk_odom_msg->twist.twist.angular.x = 0;
+        rtk_odom_msg->twist.twist.angular.y = 0;
+        rtk_odom_msg->twist.twist.angular.z = 0;
+
+        // set up the Twist covariance matrix
+        // FIXME: I don't know what the covariance of linear velocity should be.
+        // 12/19 asked on swiftnav google group
+        // GPS doesn't provide rotationl velocity
+        rtk_odom_msg->twist.covariance[0]  = driver->rtk_vel_h_covariance;   // x velocity = 0, 0 in the 6x6 cov matrix
+        rtk_odom_msg->twist.covariance[7]  = driver->rtk_vel_h_covariance;   // y velocity = 1, 1
+        rtk_odom_msg->twist.covariance[14] = driver->rtk_vel_v_covariance;   // z velocity = 2, 2
+        rtk_odom_msg->twist.covariance[21] = 1.0e3;  // x rotational velocity = 3, 3
+        rtk_odom_msg->twist.covariance[28] = 1.0e3;  // y rotational velocity = 4, 4
+        rtk_odom_msg->twist.covariance[35] = 1.0e3;  // z rotational velocity = 5, 5
+
+      driver->rtk_pub.publish( rtk_odom_msg );
+
+          driver->num_rtk_satellites = sbp_ned.n_sats;
+      driver->rtk_north = rtk_odom_msg->pose.pose.position.x;
+      driver->rtk_east = rtk_odom_msg->pose.pose.position.y;
+          driver->rtk_height = rtk_odom_msg->pose.pose.position.z;
+          driver->rtk_h_accuracy = sbp_ned.h_accuracy / 1000.0;
+          driver->rtk_v_accuracy = sbp_ned.v_accuracy / 1000.0;
+    }
+		return;
+	}
+	
+void vel_ned_callback(u16 sender_id, u8 len, u8 msg[], void *context)
+	{
+		if ( context == NULL )
+		{
+			std::cerr << "Critical Error: Pisk SBP driver vel_ned context void." << std::endl;
+			return;
+		}
+
+		class PIKSI *driver = (class PIKSI*) context;
+
+		msg_vel_ned_t sbp_vel = *(msg_vel_ned_t*) msg;
+
+        // save velocity in the Twist member of a private Odometry msg, from where it
+        // will be pulled to populate a published Odometry msg next time a
+        // msg_baseline_ned_t message is received
+        driver->rtk_vel_north = sbp_vel.n/1000.0;
+        driver->rtk_vel_east = sbp_vel.e/1000.0;
+        driver->rtk_vel_up = -sbp_vel.d/1000.0;
+        driver->rtk_vel_h_covariance = (sbp_vel.h_accuracy * sbp_vel.h_accuracy) * 10e-6;
+        driver->rtk_vel_v_covariance = (sbp_vel.v_accuracy * sbp_vel.h_accuracy) * 10e-6;
+
+		return;
+	}
+
+	void PIKSI::spin( )
+	{
+		while( ros::ok( ) )
+		{
+			boost::this_thread::interruption_point( );
+			PIKSI::spinOnce( );
+			heartbeat_diag.update( );
+			llh_diag.update( );
+			rtk_diag.update( );
+			spin_rate.sleep( );
+		}
+	}
+
+	void PIKSI::spinOnce( )
+	{
+		int ret;
+
+		cmd_lock.lock( );
+		if( piksid < 0 && !PIKSIOpenNoLock( ) )
+		{
+			cmd_lock.unlock( );
+			return;
+		}
+
+		ret = sbp_process( &state, &read_data );
+		cmd_lock.unlock( );
+	}
+
+	void PIKSI::DiagCB( diagnostic_updater::DiagnosticStatusWrapper &stat )
+	{
+		stat.summary( diagnostic_msgs::DiagnosticStatus::OK, "PIKSI status OK" );
+		boost::mutex::scoped_lock lock( cmd_lock );
+
+		if( piksid < 0 && !PIKSIOpenNoLock( ) )
+		{
+			stat.summary( diagnostic_msgs::DiagnosticStatus::ERROR, "Disconnected" );
+			return;
+		}
+		else if( open_failure_count > last_open_failure_count )
+        {
+			stat.summary( diagnostic_msgs::DiagnosticStatus::ERROR, 
+                            "Open Failure Count Increase" );
+        }
+		else if( io_failure_count > last_io_failure_count )
+        {
+			stat.summary( diagnostic_msgs::DiagnosticStatus::WARN, 
+                            "I/O Failure Count Increase" );
+        }
+        else if( 0 != heartbeat_flags & 0x7 )
+        {
+			stat.summary( diagnostic_msgs::DiagnosticStatus::ERROR, 
+                            "Piksi Error indicated by heartbeat flags" );
+        }
+
+		stat.add( "io_failure_count", io_failure_count );
+		last_io_failure_count = io_failure_count;
+
+		stat.add( "open_failure_count", open_failure_count );
+		last_open_failure_count = open_failure_count;
+
+        stat.add( "Heartbeat status (0 = good)", heartbeat_flags);
+        stat.add( "Number of satellites used in GPS RTK solution", num_rtk_satellites );
+        stat.add( "GPS RTK solution status (1 = good)", rtk_status );
+        stat.add( "GPS RTK meters north", rtk_north );
+        stat.add( "GPS RTK meters east", rtk_east );
+        stat.add( "GPS RTK height difference (m)", rtk_height );
+        stat.add( "GPS RTK horizontal accuracy (m)", rtk_h_accuracy );
+        stat.add( "GPS RTK velocity north", rtk_vel_north );
+        stat.add( "GPS RTK velocity east", rtk_vel_east );
+        stat.add( "GPS RTK velocity up", rtk_vel_up );
+        stat.add( "Number of satellites used for lat/lon", num_llh_satellites);
+        stat.add( "GPS lat/lon solution status", llh_status );
+        stat.add( "GPS latitude", llh_lat );
+        stat.add( "GPS longitude", llh_lon );
+        stat.add( "GPS altitude", llh_height );
+        stat.add( "GPS lat/lon horizontal accuracy (m)", llh_h_accuracy);
+	}
+
+}

--- a/src/swiftnav_ros_node.cpp
+++ b/src/swiftnav_ros_node.cpp
@@ -1,0 +1,80 @@
+/***************************************************************************//**
+ * \file swiftnav_ros_node.cpp
+ *
+ * \brief Single SBP device ROS node
+ * \author Josh Kretzmer
+ * \date June 23, 2017
+ *
+ * Adapted from original Swift-Nav Piksi driver authored by:
+ * Scott K Logan
+ * Caleb Jamison
+ *
+ * This binary creates a simple node for communication with a single Swift
+ * Navigation SBP Device.
+ *
+ * \section license License (BSD-3)
+ * Copyright (c) 2013, Scott K Logan\n
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of Willow Garage, Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include <swiftnav_ros/swiftnav_ros_driver.h>
+
+#include <ros/ros.h>
+#include <cstdlib>
+
+/*!
+* \brief Main Function
+*
+* Initializes ROS, instantiates the node handle for the driver to use and
+* instantiates the PIKSI class.
+*
+* \param argc Number of command line arguments
+* \param argv 2D character array of command line arguments
+*
+* \returns EXIT_SUCCESS, or an error state
+*/
+int main( int argc, char *argv[] )
+{
+	ros::init( argc, argv, "swiftnav_ros_node" );
+
+	ros::NodeHandle nh;
+	ros::NodeHandle nh_priv( "~" );
+
+	std::string port;
+	nh_priv.param( "port", port, (const std::string)"/dev/ttyUSB0" );
+
+	swiftnav_ros::PIKSI piksi( nh, nh_priv, port );
+
+	ROS_DEBUG( "Opening SBP device on %s", port.c_str( ) );
+	if( !piksi.PIKSIOpen( ) )
+		ROS_ERROR( "Failed to open SBP device on %s", port.c_str( ) );
+	else
+		ROS_INFO( "SBP device opened successfully on %s", port.c_str( ) );
+
+	ros::spin( );
+
+	std::exit( EXIT_SUCCESS );
+}


### PR DESCRIPTION
Updated sources of https://github.com/PaulBouchier/swiftnav_piksi/tree/piksi_multi including changes from @denniszollo (https://github.com/denniszollo/swiftnav_piksi/tree/sbp_2.0_ros_driver). Filenames and references have been updated to be device generic (instead of referring to Piksi or Piksi Multi). Internally, the sources still reference Piksi by name - this needs to change.