### PR TITLE
Enable the receiver in the UART termios (options).

### DIFF
--- a/src/sbp_device.c
+++ b/src/sbp_device.c
@@ -175,7 +175,7 @@ int piksi_open( const char *port, int baud )
 	}
 	options.c_cflag &= ~HUPCL;
 	options.c_lflag &= ~ICANON; 
-        options.c_cflag = CREAD;   // enable the receiver
+        options.c_cflag |= CREAD;   // enable the receiver
 	options.c_cc[VTIME] = 2;
 	options.c_cc[VMIN] = 0;
 	if( tcsetattr( fd, TCSANOW, &options ) < 0 )

--- a/src/sbp_device.c
+++ b/src/sbp_device.c
@@ -174,7 +174,8 @@ int piksi_open( const char *port, int baud )
 		return PIKSI_ERROR_IO;
 	}
 	options.c_cflag &= ~HUPCL;
-	options.c_lflag &= ~ICANON;
+	options.c_lflag &= ~ICANON; 
+        options.c_cflag = CREAD;   // enable the receiver
 	options.c_cc[VTIME] = 2;
 	options.c_cc[VMIN] = 0;
 	if( tcsetattr( fd, TCSANOW, &options ) < 0 )


### PR DESCRIPTION
In most systems, usually the CREAD bit is on, so the termios structure in the configuration inside the piksi_open() function typically works (for instance, in the case of a serial-to-USB adapter on a PC). We found  that this is not the case with the beaglebone black (and probably many other embedded platforms). The bit must be set, otherwise in most cases (sometimes you might get lucky if the bit is ON from previous UART use by another program) the driver will not intercept the data.

Regards

George Terzakis and Jaime Conde
Dynium Robot