### PR TITLE
feat: Diagnosed publisher for time

### DIFF
--- a/include/swiftnav_ros/swiftnav_ros_driver.h
+++ b/include/swiftnav_ros/swiftnav_ros_driver.h
@@ -52,6 +52,7 @@
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/publisher.h>
 #include <diagnostic_updater/update_functions.h>
+#include <sensor_msgs/TimeReference.h>
 #include <nav_msgs/Odometry.h>
 
 #include <boost/thread.hpp>
@@ -136,8 +137,10 @@ namespace swiftnav_ros
 		ros::Publisher llh_pub;
 		ros::Publisher rtk_pub;
 		ros::Publisher time_pub;
+		boost::shared_ptr<diagnostic_updater::DiagnosedPublisher<sensor_msgs::TimeReference> > diagnosed_time_pub;
 
         // Diagnostic Data
+        double expected_frequency, frequency_tolerance, timestamp_min_acceptable, timestamp_max_acceptable;
 		unsigned int io_failure_count;
 		unsigned int last_io_failure_count;
 		unsigned int open_failure_count;

--- a/src/swiftnav_ros_driver.cpp
+++ b/src/swiftnav_ros_driver.cpp
@@ -119,7 +119,7 @@ namespace swiftnav_ros
 		ros::param::param<double>("~expected_frequency", expected_frequency, 10);
 		ros::param::param<double>("~frequency_tolerance", frequency_tolerance, 0.2);
 		ros::param::param<double>("~timestamp_min_acceptable", timestamp_min_acceptable, -1);
-		ros::param::param<double>("~timestamp_max_acceptable", timestamp_max_acceptable, -1);
+		ros::param::param<double>("~timestamp_max_acceptable", timestamp_max_acceptable, 5);
 
 		diagnosed_time_pub = boost::shared_ptr<diagnostic_updater::DiagnosedPublisher<sensor_msgs::TimeReference> >(
 		      new diagnostic_updater::DiagnosedPublisher<sensor_msgs::TimeReference>(


### PR DESCRIPTION
Wrapped the time publisher in a diagnosed time publisher. We were receiving all positive diagnostics but no fix, rtkfix, time measurements were coming in due to a lack of satellites. This should be noticed by the diagnostics. Now, the diagnosed publisher will summarize a warning.